### PR TITLE
Ensure modeline pattern is initialized before any parsing

### DIFF
--- a/lib/vim-modeline.coffee
+++ b/lib/vim-modeline.coffee
@@ -44,6 +44,9 @@ module.exports = VimModeline =
     # Events subscribed to in atom's system can be easily cleaned up with a CompositeDisposable
     @subscriptions = new CompositeDisposable
 
+    @subscriptions.add atom.config.onDidChange 'vim-modeline.prefix', => @updateModelinePattern()
+    @updateModelinePattern()
+
     # Register command that toggles this view
     @subscriptions.add atom.commands.add 'atom-text-editor', 'vim-modeline:detect': => @detectAndApplyModelineSetting(null, true)
     @subscriptions.add atom.commands.add 'atom-text-editor', 'vim-modeline:insert-modeline': => @insertModeLine()
@@ -55,9 +58,6 @@ module.exports = VimModeline =
       if pkg?.mainModule.subscriptions? and not @commandDispatched
         atom.notifications.addWarning "WARNING: auto-encoding package is enabled. In this case, file encoding doesn't match the modeline. If you want use vim-modeline parse result, please invoke 'vim-modeline:detect' command or select encoding '#{encoding}'.", dismissable: true
 
-    @subscriptions.add atom.config.onDidChange 'vim-modeline.prefix', => @updateModelinePattern()
-
-    @updateModelinePattern()
 
   deactivate: ->
     @subscriptions.dispose()
@@ -123,7 +123,7 @@ module.exports = VimModeline =
   parseVimModeLine: (line) ->
     matches = line.match @modelinePattern
     options = null
-    if matches
+    if matches?[4]?
       options = {}
       for option in matches[4].split " "
         [key, value] = option.split "="


### PR DESCRIPTION
There was a bug where vim-modeline would try to parse existing text editor's content before initializing its modeline regex pattern. Since the pattern was `null`, parsing the modeline would throw an exception.

This pull request fixes that bug by initializing the modeline pattern before doing any parsing (or observing text editor elements, which will implicitly call our modeline parsing callback).

As an additional safety mechanism, `parseVimModeline()` also checks if the `matches` result from `line.match @modelinePattern` is non-null and that its 4th element if non-null, before iterating through its options. This check should prevent exceptions from being thrown if `@modelinePattern` is somehow `null` or otherwise fails to return the expected results.
